### PR TITLE
Remove temporary admin button from login screen and redirection based on domain

### DIFF
--- a/app/src/main/java/com/example/uniforlibrary/login/AuthRepository.kt
+++ b/app/src/main/java/com/example/uniforlibrary/login/AuthRepository.kt
@@ -18,12 +18,15 @@ class AuthRepository {
             val result = auth.createUserWithEmailAndPassword(email, senha).await()
             val user = result.user ?: throw Exception("Erro ao criar usuário")
 
+            // Verificar se é admin baseado no email
+            val tipo = if (email.endsWith("@adm.unifor.br")) "ADMIN" else "usuario"
+
             // Salvar dados adicionais no Firestore incluindo matrícula
             val userData = hashMapOf(
                 "nome" to nome,
                 "matricula" to matricula,
                 "email" to email,
-                "tipo" to "usuario",
+                "tipo" to tipo,
                 "criadoEm" to System.currentTimeMillis()
             )
             firestore.collection("usuarios").document(user.uid).set(userData).await()
@@ -94,7 +97,8 @@ class AuthRepository {
         return try {
             val userId = currentUser?.uid ?: return false
             val doc = firestore.collection("usuarios").document(userId).get().await()
-            doc.getString("tipo") == "admin"
+            val tipo = doc.getString("tipo")
+            tipo == "admin" || tipo == "ADMIN"
         } catch (e: Exception) {
             false
         }

--- a/app/src/main/java/com/example/uniforlibrary/login/AuthViewModel.kt
+++ b/app/src/main/java/com/example/uniforlibrary/login/AuthViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 sealed class AuthState {
     object Idle : AuthState()
     object Loading : AuthState()
-    data class Success(val message: String = "Sucesso!") : AuthState()
+    data class Success(val message: String = "Sucesso!", val isAdmin: Boolean = false) : AuthState()
     data class Error(val message: String) : AuthState()
 }
 
@@ -35,7 +35,8 @@ class AuthViewModel : ViewModel() {
 
             val result = repository.login(emailOuMatricula, senha)
             _authState.value = if (result.isSuccess) {
-                AuthState.Success("Login realizado com sucesso!")
+                val isAdmin = repository.isAdmin()
+                AuthState.Success("Login realizado com sucesso!", isAdmin)
             } else {
                 AuthState.Error(getErrorMessage(result.exceptionOrNull()))
             }
@@ -59,7 +60,8 @@ class AuthViewModel : ViewModel() {
 
             val result = repository.register(nome, matricula, email, senha)
             _authState.value = if (result.isSuccess) {
-                AuthState.Success("Cadastro realizado com sucesso!")
+                val isAdmin = repository.isAdmin()
+                AuthState.Success("Cadastro realizado com sucesso!", isAdmin)
             } else {
                 AuthState.Error(getErrorMessage(result.exceptionOrNull()))
             }

--- a/app/src/main/java/com/example/uniforlibrary/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/uniforlibrary/login/LoginActivity.kt
@@ -55,7 +55,7 @@ fun LoginScreen(viewModel: AuthViewModel = viewModel()) {
                 Toast.makeText(context, (authState as AuthState.Success).message, Toast.LENGTH_SHORT).show()
 
                 // Verificar se é admin
-                if (viewModel.isAdmin()) {
+                if ((authState as AuthState.Success).isAdmin) {
                     context.startActivity(Intent(context, HomeAdm_Activity::class.java))
                 } else {
                     context.startActivity(Intent(context, HomeActivity::class.java))
@@ -146,14 +146,6 @@ fun LoginScreen(viewModel: AuthViewModel = viewModel()) {
             enabled = authState !is AuthState.Loading
         ) {
             Text("Criar uma conta")
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-
-        OutlinedButton(
-            onClick = { context.startActivity(Intent(context, HomeAdm_Activity::class.java)) },
-            enabled = authState !is AuthState.Loading
-        ) {
-            Text("Administrador")
         }
     }
 }

--- a/app/src/main/java/com/example/uniforlibrary/login/RegisterActivity.kt
+++ b/app/src/main/java/com/example/uniforlibrary/login/RegisterActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.uniforlibrary.R
 import com.example.uniforlibrary.home.HomeActivity
+import com.example.uniforlibrary.homeAdm.HomeAdm_Activity
 import com.example.uniforlibrary.ui.theme.UniforLibraryTheme
 
 class RegisterActivity : ComponentActivity() {
@@ -54,7 +55,13 @@ fun RegisterScreen(viewModel: AuthViewModel = viewModel()) {
         when (authState) {
             is AuthState.Success -> {
                 Toast.makeText(context, (authState as AuthState.Success).message, Toast.LENGTH_SHORT).show()
-                context.startActivity(Intent(context, HomeActivity::class.java))
+
+                // Redirecionar para a página apropriada baseado no tipo de usuário
+                if ((authState as AuthState.Success).isAdmin) {
+                    context.startActivity(Intent(context, HomeAdm_Activity::class.java))
+                } else {
+                    context.startActivity(Intent(context, HomeActivity::class.java))
+                }
                 (context as? ComponentActivity)?.finish()
             }
             is AuthState.Error -> {


### PR DESCRIPTION
Remove temporary admin button from login screen

- Removed temporary "Administrador" button from LoginActivity
- Admin redirection is now handled automatically based on email domain (@adm.unifor.br)
- Simplified login UI to only include essential authentication fields
- Maintains automatic routing: admin users → HomeAdm_Activity, regular users → HomeActivity