### PR TITLE
feat: implementar upload de imagens e documentos com Cloudinary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -17,6 +19,17 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // Ler credenciais do Cloudinary do local.properties
+        val properties = Properties()
+        val localPropertiesFile = rootProject.file("local.properties")
+        if (localPropertiesFile.exists()) {
+            properties.load(localPropertiesFile.inputStream())
+        }
+
+        buildConfigField("String", "CLOUDINARY_CLOUD_NAME", "\"${properties.getProperty("cloudinary.cloud.name", "")}\"")
+        buildConfigField("String", "CLOUDINARY_API_KEY", "\"${properties.getProperty("cloudinary.api.key", "")}\"")
+        buildConfigField("String", "CLOUDINARY_API_SECRET", "\"${properties.getProperty("cloudinary.api.secret", "")}\"")
     }
 
     buildTypes {
@@ -37,6 +50,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true  // Habilitar BuildConfig
     }
 }
 
@@ -66,6 +80,9 @@ dependencies {
 
     // Coil para carregar imagens
     implementation(libs.coil.compose)
+
+    //cloudinary
+    implementation("com.cloudinary:kotlin-url-gen:1.7.0")
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/uniforlibrary/model/Producao.kt
+++ b/app/src/main/java/com/example/uniforlibrary/model/Producao.kt
@@ -1,0 +1,70 @@
+package com.example.uniforlibrary.model
+
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.PropertyName
+
+data class Producao(
+    var id: String = "",
+    val titulo: String = "",
+    val categoria: String = "",
+
+    @get:PropertyName("foto_url")
+    @set:PropertyName("foto_url")
+    var fotoUrl: String = "",
+
+    @get:PropertyName("arquivo_url")
+    @set:PropertyName("arquivo_url")
+    var arquivoUrl: String = "",
+
+    @get:PropertyName("usuario_id")
+    @set:PropertyName("usuario_id")
+    var usuarioId: String = "",
+
+    @get:PropertyName("usuario_nome")
+    @set:PropertyName("usuario_nome")
+    var usuarioNome: String = "",
+
+    val status: String = "pendente", // pendente, aprovado, rejeitado
+
+    @get:PropertyName("created_at")
+    @set:PropertyName("created_at")
+    var createdAt: Timestamp? = null,
+
+    @get:PropertyName("updated_at")
+    @set:PropertyName("updated_at")
+    var updatedAt: Timestamp? = null
+) {
+    constructor() : this(
+        id = "",
+        titulo = "",
+        categoria = "",
+        fotoUrl = "",
+        arquivoUrl = "",
+        usuarioId = "",
+        usuarioNome = "",
+        status = "pendente",
+        createdAt = null,
+        updatedAt = null
+    )
+
+    fun toMap(): Map<String, Any> {
+        val map = mutableMapOf<String, Any>(
+            "titulo" to titulo,
+            "categoria" to categoria,
+            "foto_url" to fotoUrl,
+            "arquivo_url" to arquivoUrl,
+            "usuario_id" to usuarioId,
+            "usuario_nome" to usuarioNome,
+            "status" to status,
+            "created_at" to (createdAt ?: Timestamp.now()),
+            "updated_at" to (updatedAt ?: Timestamp.now())
+        )
+
+        if (id.isNotEmpty()) {
+            map["id"] = id
+        }
+
+        return map
+    }
+}
+

--- a/app/src/main/java/com/example/uniforlibrary/profile/EditProfileActivity.kt
+++ b/app/src/main/java/com/example/uniforlibrary/profile/EditProfileActivity.kt
@@ -1,10 +1,13 @@
 package com.example.uniforlibrary.profile
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -27,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -37,6 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
 import com.example.uniforlibrary.login.LoginActivity
 import com.example.uniforlibrary.ui.theme.UniforLibraryTheme
 
@@ -78,6 +83,16 @@ fun EditProfileScreen(viewModel: ProfileViewModel = viewModel()) {
     var currentPassword by remember { mutableStateOf("") }
     var showPassword by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
+
+    // Launcher para seleção de imagem
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri?.let {
+            viewModel.uploadProfilePhoto(context, it)
+            Toast.makeText(context, "Fazendo upload da foto...", Toast.LENGTH_SHORT).show()
+        }
+    }
 
     // Atualizar dados quando o perfil for carregado
     LaunchedEffect(userProfile) {
@@ -163,15 +178,24 @@ fun EditProfileScreen(viewModel: ProfileViewModel = viewModel()) {
                         .border(3.dp, MaterialTheme.colorScheme.primary, CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
-                    Icon(
-                        Icons.Default.Person,
-                        contentDescription = "Foto de perfil",
-                        modifier = Modifier.size(60.dp),
-                        tint = MaterialTheme.colorScheme.primary
-                    )
+                    if (userProfile?.fotoUrl?.isNotEmpty() == true) {
+                        AsyncImage(
+                            model = userProfile?.fotoUrl,
+                            contentDescription = "Foto de perfil",
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Icon(
+                            Icons.Default.Person,
+                            contentDescription = "Foto de perfil",
+                            modifier = Modifier.size(60.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
                 }
                 FloatingActionButton(
-                    onClick = { showPhotoDialog = true },
+                    onClick = { imagePickerLauncher.launch("image/*") },
                     modifier = Modifier.size(36.dp),
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = Color.White

--- a/app/src/main/java/com/example/uniforlibrary/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/uniforlibrary/profile/ProfileViewModel.kt
@@ -1,5 +1,7 @@
 package com.example.uniforlibrary.profile
 
+import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -98,6 +100,23 @@ class ProfileViewModel : ViewModel() {
             } else {
                 _profileState.value = ProfileState.Error(
                     result.exceptionOrNull()?.message ?: "Erro ao atualizar telefone"
+                )
+            }
+        }
+    }
+
+    // Upload de foto de perfil
+    fun uploadProfilePhoto(context: Context, imageUri: Uri) {
+        viewModelScope.launch {
+            _profileState.value = ProfileState.Loading
+
+            val result = repository.uploadProfilePhoto(context, imageUri)
+            if (result.isSuccess) {
+                _profileState.value = ProfileState.Success("Foto de perfil atualizada com sucesso!")
+                loadUserProfile() // Recarregar perfil
+            } else {
+                _profileState.value = ProfileState.Error(
+                    result.exceptionOrNull()?.message ?: "Erro ao atualizar foto de perfil"
                 )
             }
         }

--- a/app/src/main/java/com/example/uniforlibrary/repository/ProducaoRepository.kt
+++ b/app/src/main/java/com/example/uniforlibrary/repository/ProducaoRepository.kt
@@ -1,0 +1,116 @@
+package com.example.uniforlibrary.repository
+
+import android.content.Context
+import android.net.Uri
+import com.example.uniforlibrary.model.Producao
+import com.example.uniforlibrary.service.CloudinaryService
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+class ProducaoRepository {
+    private val db = FirebaseFirestore.getInstance()
+    private val producaoCollection = db.collection("producoes")
+    private val auth = FirebaseAuth.getInstance()
+
+    // Criar nova produção
+    suspend fun addProducao(producao: Producao): Result<String> {
+        return try {
+            val docRef = producaoCollection.document()
+            val producaoWithId = producao.copy(
+                id = docRef.id,
+                createdAt = Timestamp.now(),
+                updatedAt = Timestamp.now()
+            )
+            docRef.set(producaoWithId.toMap()).await()
+            Result.success(docRef.id)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    // Upload de foto da produção
+    suspend fun uploadFotoProducao(context: Context, producaoId: String, imageUri: Uri): Result<String> {
+        return try {
+            android.util.Log.d("ProducaoRepository", "Iniciando upload de foto para produção: $producaoId")
+
+            // Fazer upload para Cloudinary na pasta "producoes"
+            val uploadResult = CloudinaryService.uploadImage(context, imageUri, "producoes", producaoId)
+
+            uploadResult.onSuccess { imageUrl ->
+                // Atualizar URL da foto no Firestore
+                producaoCollection.document(producaoId)
+                    .update(
+                        mapOf(
+                            "foto_url" to imageUrl,
+                            "updated_at" to Timestamp.now()
+                        )
+                    )
+                    .await()
+
+                android.util.Log.d("ProducaoRepository", "Foto atualizada com sucesso: $imageUrl")
+            }
+
+            uploadResult
+        } catch (e: Exception) {
+            android.util.Log.e("ProducaoRepository", "Erro ao fazer upload da foto", e)
+            Result.failure(e)
+        }
+    }
+
+    // Upload de arquivo da produção (PDF/DOC)
+    suspend fun uploadArquivoProducao(context: Context, producaoId: String, fileUri: Uri): Result<String> {
+        return try {
+            android.util.Log.d("ProducaoRepository", "Iniciando upload de arquivo para produção: $producaoId")
+
+            // Fazer upload para Cloudinary na pasta "producoes/documentos"
+            val uploadResult = CloudinaryService.uploadDocument(context, fileUri, "producoes/documentos", producaoId)
+
+            uploadResult.onSuccess { fileUrl ->
+                // Atualizar URL do arquivo no Firestore
+                producaoCollection.document(producaoId)
+                    .update(
+                        mapOf(
+                            "arquivo_url" to fileUrl,
+                            "updated_at" to Timestamp.now()
+                        )
+                    )
+                    .await()
+
+                android.util.Log.d("ProducaoRepository", "Arquivo atualizado com sucesso: $fileUrl")
+            }
+
+            uploadResult
+        } catch (e: Exception) {
+            android.util.Log.e("ProducaoRepository", "Erro ao fazer upload do arquivo", e)
+            Result.failure(e)
+        }
+    }
+
+    // Obter produções do usuário atual
+    suspend fun getMinhasProducoes(): Result<List<Producao>> {
+        return try {
+            val userId = auth.currentUser?.uid ?: throw Exception("Usuário não autenticado")
+
+            val snapshot = producaoCollection
+                .whereEqualTo("usuario_id", userId)
+                .get()
+                .await()
+
+            val producoes = snapshot.documents.mapNotNull { doc ->
+                try {
+                    doc.toObject(Producao::class.java)?.copy(id = doc.id)
+                } catch (e: Exception) {
+                    android.util.Log.e("ProducaoRepository", "Erro ao converter produção: ${doc.id}", e)
+                    null
+                }
+            }
+
+            Result.success(producoes)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/uniforlibrary/service/CloudinaryService.kt
+++ b/app/src/main/java/com/example/uniforlibrary/service/CloudinaryService.kt
@@ -1,0 +1,300 @@
+package com.example.uniforlibrary.service
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import com.example.uniforlibrary.BuildConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+import java.util.UUID
+
+class CloudinaryService {
+    companion object {
+        // Ler credenciais do BuildConfig (que vem do local.properties)
+        private val CLOUD_NAME = BuildConfig.CLOUDINARY_CLOUD_NAME
+        private val API_KEY = BuildConfig.CLOUDINARY_API_KEY
+        private val API_SECRET = BuildConfig.CLOUDINARY_API_SECRET
+        private val UPLOAD_URL = "https://api.cloudinary.com/v1_1/$CLOUD_NAME/image/upload"
+
+        /**
+         * Gera a assinatura SHA-1 para upload assinado
+         */
+        private fun generateSignature(params: Map<String, String>): String {
+            val sortedParams = params.toSortedMap()
+            val stringToSign = sortedParams.map { "${it.key}=${it.value}" }.joinToString("&") + API_SECRET
+
+            val digest = MessageDigest.getInstance("SHA-1")
+            val hash = digest.digest(stringToSign.toByteArray())
+            return hash.joinToString("") { "%02x".format(it) }
+        }
+
+        /**
+         * Faz upload de uma imagem para o Cloudinary
+         * @param context Contexto da aplicação
+         * @param imageUri URI da imagem selecionada
+         * @param folder Pasta no Cloudinary (ex: "books", "profiles")
+         * @param publicId ID público opcional (se não fornecido, será gerado automaticamente)
+         * @return URL da imagem no Cloudinary ou null em caso de erro
+         */
+        suspend fun uploadImage(
+            context: Context,
+            imageUri: Uri,
+            folder: String,
+            publicId: String? = null
+        ): Result<String> = withContext(Dispatchers.IO) {
+            try {
+                Log.d("CloudinaryService", "Iniciando upload para pasta: $folder")
+
+                // Ler bytes da imagem
+                val imageBytes = context.contentResolver.openInputStream(imageUri)?.use { input ->
+                    input.readBytes()
+                } ?: throw Exception("Não foi possível ler a imagem")
+
+                Log.d("CloudinaryService", "Imagem lida: ${imageBytes.size} bytes")
+
+                // Preparar parâmetros para assinatura
+                val timestamp = (System.currentTimeMillis() / 1000).toString()
+                val finalPublicId = "$folder/${publicId ?: UUID.randomUUID().toString()}"
+
+                val paramsForSignature = mapOf(
+                    "folder" to folder,
+                    "public_id" to finalPublicId,
+                    "timestamp" to timestamp
+                )
+
+                val signature = generateSignature(paramsForSignature)
+                Log.d("CloudinaryService", "Signature gerada: $signature")
+
+                // Criar conexão HTTP
+                val url = URL(UPLOAD_URL)
+                val boundary = "----CloudinaryBoundary${UUID.randomUUID()}"
+                val connection = (url.openConnection() as HttpURLConnection).apply {
+                    requestMethod = "POST"
+                    doOutput = true
+                    doInput = true
+                    setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+                }
+
+                // Construir corpo da requisição multipart
+                val outputStream = connection.outputStream
+                val writer = outputStream.bufferedWriter()
+
+                // Campo: file (imagem)
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"file\"; filename=\"image.jpg\"\r\n")
+                writer.append("Content-Type: image/jpeg\r\n\r\n")
+                writer.flush()
+                outputStream.write(imageBytes)
+                outputStream.flush()
+                writer.append("\r\n")
+                writer.flush()
+
+                // Campo: api_key
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"api_key\"\r\n\r\n")
+                writer.append("$API_KEY\r\n")
+                writer.flush()
+
+                // Campo: timestamp
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"timestamp\"\r\n\r\n")
+                writer.append("$timestamp\r\n")
+                writer.flush()
+
+                // Campo: signature
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"signature\"\r\n\r\n")
+                writer.append("$signature\r\n")
+                writer.flush()
+
+                // Campo: folder
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"folder\"\r\n\r\n")
+                writer.append("$folder\r\n")
+                writer.flush()
+
+                // Campo: public_id
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"public_id\"\r\n\r\n")
+                writer.append("$finalPublicId\r\n")
+                writer.flush()
+
+                // Finalizar multipart
+                writer.append("--$boundary--\r\n")
+                writer.flush()
+                writer.close()
+
+                // Ler resposta
+                val responseCode = connection.responseCode
+                Log.d("CloudinaryService", "Response code: $responseCode")
+
+                if (responseCode == HttpURLConnection.HTTP_OK) {
+                    val response = connection.inputStream.bufferedReader().use { it.readText() }
+                    Log.d("CloudinaryService", "Response: $response")
+
+                    // Extrair URL da resposta JSON
+                    val urlPattern = "\"secure_url\":\"([^\"]+)\"".toRegex()
+                    val matchResult = urlPattern.find(response)
+                    val imageUrl = matchResult?.groupValues?.get(1)
+                        ?: throw Exception("URL não encontrada na resposta")
+
+                    Log.d("CloudinaryService", "Upload bem-sucedido: $imageUrl")
+                    Result.success(imageUrl)
+                } else {
+                    val errorResponse = connection.errorStream?.bufferedReader()?.use { it.readText() }
+                        ?: "Erro desconhecido"
+                    Log.e("CloudinaryService", "Erro no upload: $errorResponse")
+                    Result.failure(Exception("Erro ao fazer upload: $errorResponse"))
+                }
+            } catch (e: Exception) {
+                Log.e("CloudinaryService", "Exceção ao fazer upload", e)
+                Result.failure(e)
+            }
+        }
+
+        /**
+         * Faz upload de foto de perfil
+         */
+        suspend fun uploadProfileImage(context: Context, imageUri: Uri, userId: String): Result<String> {
+            return uploadImage(context, imageUri, "profiles", userId)
+        }
+
+        /**
+         * Faz upload de capa de livro
+         */
+        suspend fun uploadBookCover(context: Context, imageUri: Uri, bookId: String): Result<String> {
+            return uploadImage(context, imageUri, "books", bookId)
+        }
+
+        /**
+         * Faz upload de documento (PDF, DOC, etc.)
+         */
+        suspend fun uploadDocument(
+            context: Context,
+            fileUri: Uri,
+            folder: String,
+            publicId: String? = null
+        ): Result<String> = withContext(Dispatchers.IO) {
+            try {
+                Log.d("CloudinaryService", "Iniciando upload de documento para pasta: $folder")
+
+                // Ler bytes do arquivo
+                val fileBytes = context.contentResolver.openInputStream(fileUri)?.use { input ->
+                    input.readBytes()
+                } ?: throw Exception("Não foi possível ler o arquivo")
+
+                Log.d("CloudinaryService", "Arquivo lido: ${fileBytes.size} bytes")
+
+                // Preparar parâmetros para assinatura
+                val timestamp = (System.currentTimeMillis() / 1000).toString()
+                val finalPublicId = "$folder/${publicId ?: UUID.randomUUID().toString()}"
+
+                val paramsForSignature = mapOf(
+                    "folder" to folder,
+                    "public_id" to finalPublicId,
+                    "timestamp" to timestamp,
+                    "resource_type" to "raw" // Importante para documentos
+                )
+
+                val signature = generateSignature(paramsForSignature)
+                Log.d("CloudinaryService", "Signature gerada para documento: $signature")
+
+                // Criar conexão HTTP (usar endpoint raw para documentos)
+                val uploadUrl = "https://api.cloudinary.com/v1_1/$CLOUD_NAME/raw/upload"
+                val url = URL(uploadUrl)
+                val boundary = "----CloudinaryBoundary${UUID.randomUUID()}"
+                val connection = (url.openConnection() as HttpURLConnection).apply {
+                    requestMethod = "POST"
+                    doOutput = true
+                    doInput = true
+                    setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+                }
+
+                // Construir corpo da requisição multipart
+                val outputStream = connection.outputStream
+                val writer = outputStream.bufferedWriter()
+
+                // Campo: file
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"file\"; filename=\"document.pdf\"\r\n")
+                writer.append("Content-Type: application/octet-stream\r\n\r\n")
+                writer.flush()
+                outputStream.write(fileBytes)
+                outputStream.flush()
+                writer.append("\r\n")
+                writer.flush()
+
+                // Campo: api_key
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"api_key\"\r\n\r\n")
+                writer.append("$API_KEY\r\n")
+                writer.flush()
+
+                // Campo: timestamp
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"timestamp\"\r\n\r\n")
+                writer.append("$timestamp\r\n")
+                writer.flush()
+
+                // Campo: signature
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"signature\"\r\n\r\n")
+                writer.append("$signature\r\n")
+                writer.flush()
+
+                // Campo: folder
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"folder\"\r\n\r\n")
+                writer.append("$folder\r\n")
+                writer.flush()
+
+                // Campo: public_id
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"public_id\"\r\n\r\n")
+                writer.append("$finalPublicId\r\n")
+                writer.flush()
+
+                // Campo: resource_type
+                writer.append("--$boundary\r\n")
+                writer.append("Content-Disposition: form-data; name=\"resource_type\"\r\n\r\n")
+                writer.append("raw\r\n")
+                writer.flush()
+
+                // Finalizar multipart
+                writer.append("--$boundary--\r\n")
+                writer.flush()
+                writer.close()
+
+                // Ler resposta
+                val responseCode = connection.responseCode
+                Log.d("CloudinaryService", "Response code (documento): $responseCode")
+
+                if (responseCode == HttpURLConnection.HTTP_OK) {
+                    val response = connection.inputStream.bufferedReader().use { it.readText() }
+                    Log.d("CloudinaryService", "Response: $response")
+
+                    // Extrair URL da resposta JSON
+                    val urlPattern = "\"secure_url\":\"([^\"]+)\"".toRegex()
+                    val matchResult = urlPattern.find(response)
+                    val fileUrl = matchResult?.groupValues?.get(1)
+                        ?: throw Exception("URL não encontrada na resposta")
+
+                    Log.d("CloudinaryService", "Upload de documento bem-sucedido: $fileUrl")
+                    Result.success(fileUrl)
+                } else {
+                    val errorResponse = connection.errorStream?.bufferedReader()?.use { it.readText() }
+                        ?: "Erro desconhecido"
+                    Log.e("CloudinaryService", "Erro no upload do documento: $errorResponse")
+                    Result.failure(Exception("Erro ao fazer upload: $errorResponse"))
+                }
+            } catch (e: Exception) {
+                Log.e("CloudinaryService", "Exceção ao fazer upload do documento", e)
+                Result.failure(e)
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/uniforlibrary/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/uniforlibrary/viewmodel/BookViewModel.kt
@@ -1,5 +1,7 @@
 package com.example.uniforlibrary.viewmodel
 
+import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.uniforlibrary.model.Book
@@ -156,6 +158,17 @@ class BookViewModel : ViewModel() {
             try {
                 val result = repository.returnBook(bookId)
                 _operationResult.value = result.map { "Devolução realizada com sucesso!" }
+            } catch (e: Exception) {
+                _operationResult.value = Result.failure(e)
+            }
+        }
+    }
+
+    fun uploadBookCover(context: Context, bookId: String, imageUri: Uri) {
+        viewModelScope.launch {
+            try {
+                val result = repository.uploadBookCover(context, bookId, imageUri)
+                _operationResult.value = result.map { "Capa do livro atualizada com sucesso!" }
             } catch (e: Exception) {
                 _operationResult.value = Result.failure(e)
             }

--- a/app/src/main/java/com/example/uniforlibrary/viewmodel/ProducaoViewModel.kt
+++ b/app/src/main/java/com/example/uniforlibrary/viewmodel/ProducaoViewModel.kt
@@ -1,0 +1,112 @@
+package com.example.uniforlibrary.viewmodel
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.uniforlibrary.model.Producao
+import com.example.uniforlibrary.repository.ProducaoRepository
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+sealed class ProducaoUiState {
+    object Idle : ProducaoUiState()
+    object Loading : ProducaoUiState()
+    data class Success(val message: String) : ProducaoUiState()
+    data class Error(val message: String) : ProducaoUiState()
+}
+
+class ProducaoViewModel : ViewModel() {
+    private val repository = ProducaoRepository()
+    private val auth = FirebaseAuth.getInstance()
+    private val firestore = FirebaseFirestore.getInstance()
+
+    private val _uiState = MutableStateFlow<ProducaoUiState>(ProducaoUiState.Idle)
+    val uiState: StateFlow<ProducaoUiState> = _uiState.asStateFlow()
+
+    private val _producaoId = MutableStateFlow<String?>(null)
+    val producaoId: StateFlow<String?> = _producaoId.asStateFlow()
+
+    fun submitProducao(
+        context: Context,
+        titulo: String,
+        categoria: String,
+        fotoUri: Uri?,
+        arquivoUri: Uri?
+    ) {
+        viewModelScope.launch {
+            try {
+                _uiState.value = ProducaoUiState.Loading
+
+                // Validações
+                if (titulo.isBlank()) {
+                    _uiState.value = ProducaoUiState.Error("O título é obrigatório")
+                    return@launch
+                }
+
+                if (arquivoUri == null) {
+                    _uiState.value = ProducaoUiState.Error("Selecione o arquivo da produção")
+                    return@launch
+                }
+
+                // Obter dados do usuário
+                val userId = auth.currentUser?.uid ?: throw Exception("Usuário não autenticado")
+                val userDoc = firestore.collection("usuarios").document(userId).get().await()
+                val userName = userDoc.getString("nome") ?: "Usuário"
+
+                // Criar produção no Firestore
+                val producao = Producao(
+                    titulo = titulo,
+                    categoria = categoria,
+                    usuarioId = userId,
+                    usuarioNome = userName,
+                    status = "pendente"
+                )
+
+                val result = repository.addProducao(producao)
+
+                result.onSuccess { producaoId ->
+                    _producaoId.value = producaoId
+
+                    // Upload da foto (opcional)
+                    if (fotoUri != null) {
+                        val fotoResult = repository.uploadFotoProducao(context, producaoId, fotoUri)
+                        fotoResult.onFailure { e ->
+                            android.util.Log.e("ProducaoViewModel", "Erro ao fazer upload da foto", e)
+                        }
+                    }
+
+                    // Upload do arquivo (obrigatório)
+                    val arquivoResult = repository.uploadArquivoProducao(context, producaoId, arquivoUri)
+
+                    arquivoResult.onSuccess {
+                        _uiState.value = ProducaoUiState.Success(
+                            "Produção enviada com sucesso! Aguarde a avaliação do comitê."
+                        )
+                    }.onFailure { e ->
+                        _uiState.value = ProducaoUiState.Error(
+                            "Erro ao fazer upload do arquivo: ${e.message}"
+                        )
+                    }
+
+                }.onFailure { e ->
+                    _uiState.value = ProducaoUiState.Error("Erro ao criar produção: ${e.message}")
+                }
+
+            } catch (e: Exception) {
+                _uiState.value = ProducaoUiState.Error("Erro inesperado: ${e.message}")
+            }
+        }
+    }
+
+    fun resetState() {
+        _uiState.value = ProducaoUiState.Idle
+        _producaoId.value = null
+    }
+}
+


### PR DESCRIPTION
- Adicionar CloudinaryService com upload assinado (SHA-1 signature)
- Implementar upload de foto de perfil do usuário
- Implementar upload de capa de livro
- Implementar upload de foto e arquivo PDF/DOC em Produzir
- Adicionar suporte para upload de documentos (PDF, DOC, DOCX)
- Proteger credenciais da API no local.properties
- Configurar BuildConfig para ler variáveis de ambiente
- Adicionar modelo, repository e viewmodel para Produção
- Implementar validações e feedback visual (loading, toasts)
- Atualizar ProduzirScreen com launchers para arquivo e foto
- Adicionar permissões de internet no AndroidManifest
- Criar documentação sobre configuração de credenciais

BREAKING CHANGE: Requer configuração de credenciais Cloudinary no local.properties